### PR TITLE
added beds reserved field in logs table

### DIFF
--- a/data/migrations/20201209155624_logs.js
+++ b/data/migrations/20201209155624_logs.js
@@ -29,6 +29,8 @@ exports.up = function (knex) {
     tbl.date('date');
 
     tbl.datetime('time');
+
+    tbl.integer('beds_reserved');
   });
 };
 


### PR DESCRIPTION
Added beds_reserved field to keep track of how many beds a family reserves per night.
​
Addition of a column in the guestLogs table
This is needed so Supervisors and Case Managers can keep track of a families profile.    
Which user story or task is this PR tied to?
1. As a Guest, I can reserve a bed in the shelter using my Guest profile and log how many beds I need

How many files and/or lines were changed? 
1 line, 1 file.
​
​
## Type of Change
​
Types of Change:

- [x] New feature
- [x] Refactoring / Bug fix
- [] Documentation update
- [] Executive Change (technical decision change overwrite)
    - Reason for change (required):
​
​
## Testing
​
- [] Yes
- [x] No
- [] Not needed
​
​
## Completeness
Is this feature complete
- [] Feature Complete
- [x] Feature Incomplete
- [] User story/trello card linked here
- https://trello.com/c/UnnX4lE4/8-1-as-a-guest-i-can-reserve-a-bed-in-the-shelter-using-my-guest-profile-and-log-how-many-beds-i-need  
​
# PR Requirements
- [] Clean and concise commenting
- [] Clean and comprehensive documentation included
- [] Conforms to engineering standards and checks
- [] There are no merge conflicts
- [] There are no warnings
- [] Corresponding documentation elsewhere has been updated to reflect these changes
​
​
## Requester Questions
​
```Add any questions, comments, or concerns you have as the person initiating the pull request for your reviewers```
​
​
## Other
[Rubric](https://www.notion.so/1fc04e4fedeb429ba873b7c68d281707?v=74054da7991341c0bf970f39410c43da)  
[Template Guidelines](https://www.notion.so/Pull-Request-Template-f9264f79e1b649b9845961b5aba3eaff)
​
